### PR TITLE
Improve performance of FastOR

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -532,11 +532,32 @@ func (bc *bitmapContainer) iorBitmap(value2 *bitmapContainer) container {
 func (bc *bitmapContainer) lazyIORArray(value2 *arrayContainer) container {
 	answer := bc
 	c := value2.getCardinality()
-	for k := 0; k < c; k++ {
+	for k := 0; k+3 < c; k += 4 {
+		content := (*[4]uint16)(unsafe.Pointer(&value2.content[k]))
+		vc0 := content[0]
+		i0 := uint(vc0) >> 6
+		answer.bitmap[i0] = answer.bitmap[i0] | (uint64(1) << (vc0 % 64))
+
+		vc1 := content[1]
+		i1 := uint(vc1) >> 6
+		answer.bitmap[i1] = answer.bitmap[i1] | (uint64(1) << (vc1 % 64))
+
+		vc2 := content[2]
+		i2 := uint(vc2) >> 6
+		answer.bitmap[i2] = answer.bitmap[i2] | (uint64(1) << (vc2 % 64))
+
+		vc3 := content[3]
+		i3 := uint(vc3) >> 6
+		answer.bitmap[i3] = answer.bitmap[i3] | (uint64(1) << (vc3 % 64))
+	}
+
+	// k := c - c%4
+	for k := c &^ 3; k < c; k++ {
 		vc := value2.content[k]
 		i := uint(vc) >> 6
 		answer.bitmap[i] = answer.bitmap[i] | (uint64(1) << (vc % 64))
 	}
+
 	answer.cardinality = invalidCardinality
 	return answer
 }


### PR DESCRIPTION
This PR optimises `FastOR` by unrolling one of the hot loops in the `arrayContainer`. 

This method was showing up a lot for smaller bitmaps with fewer than 10,000 elements in that were being unioned _a lot_.

For some internal influx benchmarks this change improved the performance of `FastOR` by around 28%, but I've included some roaring benchmarks below:

```
name                                     old time/op    new time/op    delta
RealDataFastOr/census-income_srt-8          354µs ± 7%     388µs ±11%   +9.60%  (p=0.000 n=10+10)
RealDataFastOr/census-income-8              774µs ± 5%     727µs ±12%   -6.10%  (p=0.007 n=10+10)
RealDataFastOr/census1881_srt-8             875µs ± 4%     870µs ± 1%     ~     (p=0.515 n=10+8)
RealDataFastOr/census1881-8                1.48ms ± 4%    1.22ms ± 2%  -17.97%  (p=0.000 n=10+9)
RealDataFastOr/dimension_003-8             1.23ms ± 5%    1.18ms ± 1%   -4.27%  (p=0.000 n=10+10)
RealDataFastOr/dimension_008-8              527µs ± 3%     520µs ± 2%     ~     (p=0.089 n=10+10)
RealDataFastOr/dimension_033-8              529µs ± 2%     525µs ± 6%     ~     (p=0.182 n=9+10)
RealDataFastOr/uscensus2000-8              1.74ms ± 7%    1.71ms ± 0%     ~     (p=0.780 n=10+9)
RealDataFastOr/weather_sept_85_srt-8        281µs ± 6%     276µs ± 3%     ~     (p=0.105 n=10+10)
RealDataFastOr/weather_sept_85-8           3.39ms ± 2%    2.97ms ± 2%  -12.35%  (p=0.000 n=10+10)
RealDataFastOr/wikileaks-noquotes_srt-8     172µs ± 2%     168µs ± 1%   -2.64%  (p=0.000 n=10+10)
RealDataFastOr/wikileaks-noquotes-8         295µs ± 4%     288µs ± 3%   -2.65%  (p=0.043 n=10+10)

name                                     old alloc/op   new alloc/op   delta
RealDataFastOr/census-income_srt-8         72.4kB ± 0%    72.4kB ± 0%     ~     (all equal)
RealDataFastOr/census-income-8             42.6kB ± 0%    42.6kB ± 0%     ~     (all equal)
RealDataFastOr/census1881_srt-8             823kB ± 0%     823kB ± 0%     ~     (all equal)
RealDataFastOr/census1881-8                 603kB ± 0%     603kB ± 0%     ~     (all equal)
RealDataFastOr/dimension_003-8              503kB ± 0%     503kB ± 0%     ~     (p=1.000 n=10+10)
RealDataFastOr/dimension_008-8              456kB ± 0%     456kB ± 0%     ~     (all equal)
RealDataFastOr/dimension_033-8              879kB ± 0%     879kB ± 0%     ~     (all equal)
RealDataFastOr/uscensus2000-8              3.92MB ± 0%    3.92MB ± 0%     ~     (p=0.481 n=10+9)
RealDataFastOr/weather_sept_85_srt-8        248kB ± 0%     248kB ± 0%   -0.00%  (p=0.006 n=10+9)
RealDataFastOr/weather_sept_85-8            141kB ± 0%     141kB ± 0%     ~     (all equal)
RealDataFastOr/wikileaks-noquotes_srt-8     211kB ± 0%     211kB ± 0%     ~     (all equal)
RealDataFastOr/wikileaks-noquotes-8         195kB ± 0%     195kB ± 0%     ~     (all equal)

name                                     old allocs/op  new allocs/op  delta
RealDataFastOr/census-income_srt-8           30.0 ± 0%      30.0 ± 0%     ~     (all equal)
RealDataFastOr/census-income-8               24.0 ± 0%      24.0 ± 0%     ~     (all equal)
RealDataFastOr/census1881_srt-8               390 ± 0%       390 ± 0%     ~     (all equal)
RealDataFastOr/census1881-8                   286 ± 0%       286 ± 0%     ~     (all equal)
RealDataFastOr/dimension_003-8                377 ± 0%       377 ± 0%     ~     (all equal)
RealDataFastOr/dimension_008-8                339 ± 0%       339 ± 0%     ~     (all equal)
RealDataFastOr/dimension_033-8                377 ± 0%       377 ± 0%     ~     (all equal)
RealDataFastOr/uscensus2000-8               2.99k ± 0%     2.99k ± 0%     ~     (all equal)
RealDataFastOr/weather_sept_85_srt-8          105 ± 0%       105 ± 0%     ~     (all equal)
RealDataFastOr/weather_sept_85-8             75.0 ± 0%      75.0 ± 0%     ~     (all equal)
RealDataFastOr/wikileaks-noquotes_srt-8       106 ± 0%       106 ± 0%     ~     (all equal)
RealDataFastOr/wikileaks-noquotes-8           100 ± 0%       100 ± 0%     ~     (all equal)
```

As you can see, one of the benchmarks ends up worse off (`RealDataFastOr/census-income_srt-8`).  It's likely that these bitsets are not similar to those we see in our systems. 

As such, I probably won't push this upstream, but we should merge it into our fork for now.